### PR TITLE
Fix Whisper to hear players correctly

### DIFF
--- a/classes/whisper.py
+++ b/classes/whisper.py
@@ -2,7 +2,7 @@ import whisper
 import pyaudio
 import wave
 from pydub import AudioSegment
-
+import logging
 
 class WhisperTranscriber:
     def __init__(self):
@@ -26,8 +26,8 @@ class WhisperTranscriber:
         channels = 1
         rate = 16000
         chunk = 1024
-        silence_threshold = -40  # Silence threshold in dB
-        silence_duration = 1000  # Duration of silence in ms (1 second)
+        silence_threshold = -50  # Adjusted silence threshold in dB
+        silence_duration = 0.5  # Adjusted duration of silence in seconds
 
         # Open the audio stream
         stream = p.open(format=format,
@@ -59,7 +59,7 @@ class WhisperTranscriber:
                 silent_chunks = 0
 
             # Stop recording after detecting sufficient silence
-            if silent_chunks > silence_duration / (1000 * chunk / rate):
+            if silent_chunks > silence_duration * (rate / chunk):
                 break
 
         # Stop and close the stream
@@ -88,6 +88,17 @@ class WhisperTranscriber:
         ]
 
         if text not in unwanted_responses:
+            logging.info(f"Transcribed text: {text}")
             return text
         else:
+            logging.info("Unwanted response detected.")
             return ""
+
+    def start_listening(self):
+        """
+        Starts listening for speech input and returns the transcribed text.
+        Returns:
+            str: The transcribed text from the audio input.
+        """
+        logging.info("Listening for speech input...")
+        return self.get_speech_input()

--- a/nova.py
+++ b/nova.py
@@ -1,3 +1,5 @@
+import logging
+
 def run_code():
     from classes.whisper import WhisperTranscriber
     from classes.system_prompt import SystemPrompt
@@ -123,8 +125,10 @@ def run_code():
         user_speech = ""
 
         while not user_speech:
-            user_speech = transcriber.get_speech_input()
+            user_speech = transcriber.start_listening()
+            if not user_speech:
+                logging.info("No speech detected, waiting for input...")
 
-        f"HUMAN: {user_speech}"
+        logging.info(f"HUMAN: {user_speech}")
 
         JsonWrapper.write(constant.HISTORY_PATH, user_speech)


### PR DESCRIPTION
Fix the issue where Nova cannot hear other people speak.

* **`classes/whisper.py`**
  - Update the `get_speech_input` method to fix the silence detection logic.
  - Adjust the silence threshold to -50 dB and duration to 0.5 seconds for better performance.
  - Add logging to the `get_speech_input` method for debugging purposes.
  - Add a `start_listening` method to start listening for speech input and return the transcribed text.

* **`nova.py`**
  - Add logging to the loop that waits for user speech input for debugging purposes.
  - Update the loop to call the `start_listening` method instead of `get_speech_input`.
  - Handle empty responses by logging a message and waiting for input.

