### PR TITLE
Refactor movement methods to use asynchronous calls

### DIFF
--- a/classes/osc.py
+++ b/classes/osc.py
@@ -130,7 +130,7 @@ class VRChatOSC:
         await asyncio.sleep(seconds)
         self.client.send_message("/input/MoveBackward", 0)
 
-    def move_left(self, seconds: float):
+    async def move_left(self, seconds: float):
         """
         Sends a command to make the avatar strafe left.
         Args:
@@ -138,7 +138,7 @@ class VRChatOSC:
         """
 
         self.client.send_message("/input/MoveLeft", 1)
-        time.sleep(seconds)
+        await asyncio.sleep(seconds)
         self.client.send_message("/input/MoveLeft", 0)
 
     async def move_right(self, seconds: float):
@@ -149,5 +149,5 @@ class VRChatOSC:
         """
 
         self.client.send_message("/input/MoveRight", 1)
-        time.sleep(seconds)
+        await asyncio.sleep(seconds)
         self.client.send_message("/input/MoveRight", 0)


### PR DESCRIPTION
This pull request updates the movement methods in the `osc.py` class to use asynchronous sleep instead of blocking sleep, ensuring that the event loop is not blocked during avatar movement commands.

**Improvements to movement methods:**

* Changed `move_left` and `move_right` methods to use `await asyncio.sleep(seconds)` instead of `time.sleep(seconds)`, making them fully asynchronous and non-blocking. [[1]](diffhunk://#diff-91d4dedd51a14703ec36007f3ac82056604e462054e68f648d76c5037f9c8dc2L133-R141) [[2]](diffhunk://#diff-91d4dedd51a14703ec36007f3ac82056604e462054e68f648d76c5037f9c8dc2L152-R152)
* Updated `move_left` method to be an `async def` function for consistency with other movement methods.