### PR TITLE
Limit avatar movement duration and improve docstring clarity

### DIFF
--- a/classes/osc.py
+++ b/classes/osc.py
@@ -76,7 +76,7 @@ class VRChatOSC:
         """
 
         self.client.send_message("/input/LookLeft", 1)
-        await asyncio.sleep(seconds)
+        await asyncio.sleep(min(seconds, 3))
         self.client.send_message("/input/LookLeft", 0)
 
     async def look_right(self, seconds: float):
@@ -87,7 +87,7 @@ class VRChatOSC:
         """
 
         self.client.send_message("/input/LookRight", 1)
-        await asyncio.sleep(seconds)
+        await asyncio.sleep(min(seconds, 3))
         self.client.send_message("/input/LookRight", 0)
 
     async def jump(self):
@@ -116,7 +116,7 @@ class VRChatOSC:
         """
 
         self.client.send_message("/input/MoveForward", 1)
-        await asyncio.sleep(seconds)
+        await asyncio.sleep(min(seconds, 10))
         self.client.send_message("/input/MoveForward", 0)
 
     async def move_backward(self, seconds: float):
@@ -127,7 +127,7 @@ class VRChatOSC:
         """
 
         self.client.send_message("/input/MoveBackward", 1)
-        await asyncio.sleep(seconds)
+        await asyncio.sleep(min(seconds, 10))
         self.client.send_message("/input/MoveBackward", 0)
 
     async def move_left(self, seconds: float):
@@ -138,7 +138,7 @@ class VRChatOSC:
         """
 
         self.client.send_message("/input/MoveLeft", 1)
-        await asyncio.sleep(seconds)
+        await asyncio.sleep(min(seconds, 5))
         self.client.send_message("/input/MoveLeft", 0)
 
     async def move_right(self, seconds: float):
@@ -149,5 +149,5 @@ class VRChatOSC:
         """
 
         self.client.send_message("/input/MoveRight", 1)
-        await asyncio.sleep(seconds)
+        await asyncio.sleep(min(seconds, 5))
         self.client.send_message("/input/MoveRight", 0)

--- a/classes/tool_definitions.py
+++ b/classes/tool_definitions.py
@@ -23,13 +23,13 @@ from classes.memory import MemoryManager, MemoryType
 
 def toggle_voice():
     """
-    Toggles the voice chat state. Sends /input/Voice with value 1 to disable and 0 to enable.
+    Toggles the voice chat state. Only use when the user explicitly asks you to mute/unmute your mic.
     """
 
 
 def look_left(seconds: float):
     """
-    Sends a command to make the avatar look left for a specified duration.
+    Sends a command to make your avatar look left for a specified duration.
 
     Args:
         seconds: The amount of time in seconds to look left.
@@ -38,7 +38,7 @@ def look_left(seconds: float):
 
 def look_right(seconds: float):
     """
-    Sends a command to make the avatar look right for a specified duration.
+    Sends a command to make your avatar look right for a specified duration.
 
     Args:
         seconds: The amount of time in seconds to look right.
@@ -47,7 +47,7 @@ def look_right(seconds: float):
 
 def jump():
     """
-    Sends a command to make the avatar jump.
+    Sends a command to make your avatar jump.
     """
 
 
@@ -63,7 +63,7 @@ def send_osc(address: str, value):
 
 def move_forward(seconds: float):
     """
-    Sends a command to make the avatar move forward for a specified duration.
+    Sends a command to make your avatar move forward for a specified duration.
 
     Args:
         seconds: The amount of time in seconds to move forward.
@@ -72,7 +72,7 @@ def move_forward(seconds: float):
 
 def move_backward(seconds: float):
     """
-    Sends a command to make the avatar move backward for a specified duration.
+    Sends a command to make your avatar move backward for a specified duration.
 
     Args:
         seconds: The amount of time in seconds to move backward.
@@ -81,7 +81,7 @@ def move_backward(seconds: float):
 
 def move_left(seconds: float):
     """
-    Sends a command to make the avatar strafe left for a specified duration.
+    Sends a command to make your avatar strafe left for a specified duration.
 
     Args:
         seconds: The amount of time in seconds to strafe left.
@@ -90,7 +90,7 @@ def move_left(seconds: float):
 
 def move_right(seconds: float):
     """
-    Sends a command to make the avatar strafe right for a specified duration.
+    Sends a command to make your avatar strafe right for a specified duration.
 
     Args:
         seconds: The amount of time in seconds to strafe right.


### PR DESCRIPTION
This pull request introduces safety limits to the duration of avatar movement and look actions in `classes/osc.py`, ensuring that commands do not run for excessively long periods. Additionally, it clarifies and improves the wording of docstrings in `classes/tool_definitions.py` to make them more user-focused and precise.

**Safety limits for movement and look actions:**

* Added maximum duration limits to avatar actions in `classes/osc.py`: look left/right actions are now capped at 3 seconds, move forward/backward at 10 seconds, and move left/right at 5 seconds. This prevents commands from running longer than intended and improves safety and control. [[1]](diffhunk://#diff-91d4dedd51a14703ec36007f3ac82056604e462054e68f648d76c5037f9c8dc2L79-R79) [[2]](diffhunk://#diff-91d4dedd51a14703ec36007f3ac82056604e462054e68f648d76c5037f9c8dc2L90-R90) [[3]](diffhunk://#diff-91d4dedd51a14703ec36007f3ac82056604e462054e68f648d76c5037f9c8dc2L119-R119) [[4]](diffhunk://#diff-91d4dedd51a14703ec36007f3ac82056604e462054e68f648d76c5037f9c8dc2L130-R130) [[5]](diffhunk://#diff-91d4dedd51a14703ec36007f3ac82056604e462054e68f648d76c5037f9c8dc2L141-R141) [[6]](diffhunk://#diff-91d4dedd51a14703ec36007f3ac82056604e462054e68f648d76c5037f9c8dc2L152-R152)

**Docstring and documentation improvements:**

* Updated docstrings in `classes/tool_definitions.py` to use "your avatar" instead of "the avatar" for a more user-centric tone and clarified the descriptions for all movement and look functions. [[1]](diffhunk://#diff-08ba361daa7621da6828e02bcd4999a7679c8f741743ef57c3d55f3fc9844542L26-R32) [[2]](diffhunk://#diff-08ba361daa7621da6828e02bcd4999a7679c8f741743ef57c3d55f3fc9844542L41-R41) [[3]](diffhunk://#diff-08ba361daa7621da6828e02bcd4999a7679c8f741743ef57c3d55f3fc9844542L50-R50) [[4]](diffhunk://#diff-08ba361daa7621da6828e02bcd4999a7679c8f741743ef57c3d55f3fc9844542L66-R66) [[5]](diffhunk://#diff-08ba361daa7621da6828e02bcd4999a7679c8f741743ef57c3d55f3fc9844542L75-R75) [[6]](diffhunk://#diff-08ba361daa7621da6828e02bcd4999a7679c8f741743ef57c3d55f3fc9844542L84-R84) [[7]](diffhunk://#diff-08ba361daa7621da6828e02bcd4999a7679c8f741743ef57c3d55f3fc9844542L93-R93)
* Clarified the `toggle_voice` docstring to specify that it should only be used when the user explicitly requests a mute/unmute action.